### PR TITLE
fix bug with DDEnum

### DIFF
--- a/include/ddynamic_reconfigure/dd_param.h
+++ b/include/ddynamic_reconfigure/dd_param.h
@@ -16,7 +16,7 @@ using namespace std;
 namespace ddynamic_reconfigure {
     class DDParam;// declaration for the sake of order.
     // this is the pointer to any type of Dynamic Dynamic parameter.
-    typedef shared_ptr<DDParam> DDPtr;
+    typedef boost::shared_ptr<DDParam> DDPtr;
     /**
      * @brief The DDParam class is the abstraction of all parameter types, and is the template for creating them.
      *        At this point, not much is known about the parameter, but the following:

--- a/include/ddynamic_reconfigure/dd_value.h
+++ b/include/ddynamic_reconfigure/dd_value.h
@@ -98,7 +98,7 @@ namespace ddynamic_reconfigure {
             if (type_ == "string") {
                 int i;
                 if (sscanf(str_val_.c_str(), "%d", &i) == 0) {
-                    return (int) hash<string>()(str_val_);
+                    return (int) boost::hash<string>()(str_val_);
                 }
                 return i;
             } else if (type_ == "bool") { return bool_val_ ? 1 : 0; }
@@ -134,7 +134,7 @@ namespace ddynamic_reconfigure {
             if(type_ == "string") {
                 double f;
                 if(sscanf(str_val_.c_str(), "%lf", &f) == 0) {
-                    return hash<string>()(str_val_);
+                    return boost::hash<string>()(str_val_);
                 }
                 return f;
             } else if(type_ == "bool") {return bool_val_ ? 1.0 : 0.0;}

--- a/include/ddynamic_reconfigure/ddynamic_reconfigure.h
+++ b/include/ddynamic_reconfigure/ddynamic_reconfigure.h
@@ -24,7 +24,7 @@ namespace ddynamic_reconfigure {
     // this is a map from the DDParam name to the object. Acts like a set with a search function.
     typedef map<string,DDPtr> DDMap;
     // the function you will use a lot
-    typedef function<void(const DDMap&,int)> DDFunc;
+    typedef boost::function<void(const DDMap&,int)> DDFunc;
 
     /**
      * @brief The DDynamicReconfigure class is the main class responsible for keeping track of parameters basic properties,
@@ -209,7 +209,7 @@ namespace ddynamic_reconfigure {
          /**
           * @brief the use defined callback to call when parameters are updated.
           */
-          shared_ptr<DDFunc> callback_;
+          boost::shared_ptr<DDFunc> callback_;
           #pragma clang diagnostic push // CLion suppressor
           #pragma ide diagnostic ignored "OCUnusedGlobalDeclarationInspection"
          /**

--- a/src/param/dd_enum_param.cpp
+++ b/src/param/dd_enum_param.cpp
@@ -136,7 +136,7 @@ namespace ddynamic_reconfigure {
             ret << "'description': '" << desc << "', ";
             ret << "'srcfile': '/does/this/really/matter.cfg', "; // the answer is no. This is useless.
             ret << "'cconsttype': 'const int', ";
-            ret << "'value': '" << value << "', ";
+            ret << "'value': " << value << ", ";
             ret << "'ctype': 'int', ";
             ret << "'type': 'int', ";
             ret << "'name': '" << name << "'";


### PR DESCRIPTION
Fixing the DDEnum bug reported in issue #2.

- dd_enum_param.cpp: remove extra quotation mark from field "value" - This fixed the bug for me.
- Add some "boost::" headers to fix ambiguity errors I encountered in compilation.