### PR TITLE
Point users to PAL version prominently

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 DDynamic-Reconfigure
 ==================================================
+
+PAL has released their version: https://github.com/pal-robotics/ddynamic_reconfigure
+
 [![Build Status](http://venus:8080/view/Integration%20Jobs/job/I40-ddynamic_reconfigure-dubnium-devel_dubnium/badge/icon)](http://venus:8080/view/Integration%20Jobs/job/I40-ddynamic_reconfigure-dubnium-devel_dubnium/)
 
 The DDynamic-Reconfigure package (or 2D-reconfig) is a **C++** based extension to Dynamic-Reconfigure (or 1D-reconfig) which allows C++ based nodes to self-initiate.


### PR DESCRIPTION
Following https://github.com/awesomebytes/ddynamic_reconfigure/pull/7#issuecomment-1266171724

> note that this repo comes from a time where ddynamic_reconfigure was not in a state to be shared publicly and PAL gave me permission to publish a stripped fork to work as a community to make it open source. Meanwhile, PAL has released their version: https://github.com/pal-robotics/ddynamic_reconfigure
> Maybe you are using this one and PAL's official one is just too different for you, but I thought I'd point it out, just in case.

The repo `about` section could also be made to point at the other repo

Maybe exact wording here could be made even stronger, open with something like 'this version is DEPRECATED'